### PR TITLE
Code Insights Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,21 @@ RUN apk add wget bash
 RUN cd / && wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-bash/raw/0.4.0/common.sh
 RUN chmod a+x /*.sh
 
+COPY ./code-insights /usr/bin/code-insights
+# Install python/pip
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+RUN pip3 install pipenv
+RUN python3 --version
+RUN chown 1000 /usr/bin/code-insights
+
 # https://github.com/jeremylong/DependencyCheck/blob/2d5fbd9719ddd55a59aea8c234c11e43eaafe26d/Dockerfile#L50
 USER 1000
+
+RUN cd /usr/bin/code-insights && pipenv install
+RUN cd /usr/bin/code-insights && pipenv run code-insights
 
 RUN /usr/share/dependency-check/bin/dependency-check.sh --updateonly
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod a+x /*.sh
 USER 1000
 RUN /usr/share/dependency-check/bin/dependency-check.sh --updateonly
 
-# Install python/pip
+# Install python environment
 USER root 
 COPY ./code-insights /usr/bin/code-insights
 ENV PYTHONUNBUFFERED=1
@@ -25,7 +25,5 @@ RUN chown 1000 /usr/bin/code-insights
 # Install python code-insight dependencies 
 USER 1000
 RUN cd /usr/bin/code-insights && pipenv install
-RUN cd /usr/bin/code-insights && pipenv run code-insights
-
 
 ENTRYPOINT ["/pipe.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,14 @@ RUN apk add wget bash
 RUN cd / && wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-bash/raw/0.4.0/common.sh
 RUN chmod a+x /*.sh
 
-COPY ./code-insights /usr/bin/code-insights
+# Initialise OWASP DB
+# https://github.com/jeremylong/DependencyCheck/blob/2d5fbd9719ddd55a59aea8c234c11e43eaafe26d/Dockerfile#L50
+USER 1000
+RUN /usr/share/dependency-check/bin/dependency-check.sh --updateonly
+
 # Install python/pip
+USER root 
+COPY ./code-insights /usr/bin/code-insights
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3
 RUN python3 -m ensurepip
@@ -16,12 +22,10 @@ RUN pip3 install pipenv
 RUN python3 --version
 RUN chown 1000 /usr/bin/code-insights
 
-# https://github.com/jeremylong/DependencyCheck/blob/2d5fbd9719ddd55a59aea8c234c11e43eaafe26d/Dockerfile#L50
+# Install python code-insight dependencies 
 USER 1000
-
 RUN cd /usr/bin/code-insights && pipenv install
 RUN cd /usr/bin/code-insights && pipenv run code-insights
 
-RUN /usr/share/dependency-check/bin/dependency-check.sh --updateonly
 
 ENTRYPOINT ["/pipe.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,7 @@ COPY ./code-insights /usr/bin/code-insights
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3
 RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
-RUN pip3 install pipenv
-RUN python3 --version
-RUN chown 1000 /usr/bin/code-insights
+RUN pip3 install --no-cache --upgrade pip setuptools junitparser requests
 
-# Install python code-insight dependencies 
 USER 1000
-RUN cd /usr/bin/code-insights && pipenv install
-
 ENTRYPOINT ["/pipe.sh"]

--- a/code-insights/Pipfile
+++ b/code-insights/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+junitparser = "*"
+requests = "*"
+
+[dev-packages]
+
+[scripts]
+code-insights = "python code-insights.py"
+
+[requires]
+python_version = "3.9"

--- a/code-insights/Pipfile.lock
+++ b/code-insights/Pipfile.lock
@@ -1,0 +1,73 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b89aada066a08e7fd338bde68537ab6340d70b5ebf59a0c57c0d5c19485066d4"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
+                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.10"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "version": "==0.18.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
+        },
+        "junitparser": {
+            "hashes": [
+                "sha256:35f8f5df8fe988435c3d378befff98fa8b44724427f1ad11c7f510fa3830f50f",
+                "sha256:c2d9c83bef4712da18090935cbed430e6041915986c097f7a58f35797ddf6065"
+            ],
+            "index": "pypi",
+            "version": "==2.4.2"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+            ],
+            "index": "pypi",
+            "version": "==2.27.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+            ],
+            "version": "==1.26.8"
+        }
+    },
+    "develop": {}
+}

--- a/code-insights/README.md
+++ b/code-insights/README.md
@@ -1,0 +1,3 @@
+# Code Insights
+This Python 3 package is responsible for interfacing with Bitbuckets code insights feature.
+It is currently internal to the `aligent/owasp-dependency-check-pipe` but will likely be extracted at some point in the future.

--- a/code-insights/code-insights.py
+++ b/code-insights/code-insights.py
@@ -9,6 +9,7 @@ BITBUCKET_COMMIT = os.getenv('BITBUCKET_COMMIT')
 BITBUCKET_PIPELINE_UUID = os.getenv('BITBUCKET_PIPELINE_UUID')
 BITBUCKET_STEP_UUID = os.getenv('BITBUCKET_STEP_UUID')
 PROXIES = {"http": 'http://host.docker.internal:29418'}
+DEBUG = os.getenv('DEBUG')
 
 def create_report(title, details, report_type, report_id, reporter, result, data):
     url=f"http://api.bitbucket.org/2.0/repositories/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/commit/{BITBUCKET_COMMIT}/reports/{reporter}-{report_id}"
@@ -36,6 +37,8 @@ def create_annotation(title, summary, severity, path, line, reporter, report_id,
             "path": path,
             "line": line
             }
+    if DEBUG:
+        print(body)
     r = requests.put(url=url, json=body, proxies=PROXIES)
     if not r.ok:
         print(f"Failed to create annotation {title}")

--- a/code-insights/code-insights.py
+++ b/code-insights/code-insights.py
@@ -77,7 +77,7 @@ def build_report_data(failure_count):
 
 parser = argparse.ArgumentParser(description='Interface with the Bitbucket Code Insights API')
 subparsers = parser.add_subparsers(dest="cmd")
-create_parser = subparsers.add_parser('create-report')
+create_parser = subparsers.add_parser('junit-report')
 
 create_parser.add_argument('title', type=str)
 create_parser.add_argument('details', type=str)
@@ -102,4 +102,4 @@ if args.cmd == 'junit-report':
             args.reporter,
             "FAILED" if len(failures) else "PASSED",
             f"https://bitbucket.org/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/addon/pipelines/home#!/results/{BITBUCKET_PIPELINE_UUID}/steps/{BITBUCKET_STEP_UUID}/test-report",
-            build_report_data(len(failures))
+            build_report_data(len(failures)))

--- a/code-insights/code-insights.py
+++ b/code-insights/code-insights.py
@@ -12,7 +12,7 @@ PROXIES = {"http": 'http://host.docker.internal:29418'}
 DEBUG = os.getenv('DEBUG')
 
 def create_report(title, details, report_type, report_id, reporter, result, data):
-    url=f"http://api.bitbucket.org/2.0/repositories/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/commit/{BITBUCKET_COMMIT}/reports/{reporter}-{report_id}"
+    url=f"http://api.bitbucket.org/2.0/repositories/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/commit/{BITBUCKET_COMMIT}/reports/{reporter}-{report_id}/test-report"
     body = { 
             "title": details,
             "details": title,

--- a/code-insights/code-insights.py
+++ b/code-insights/code-insights.py
@@ -8,7 +8,7 @@ BITBUCKET_REPO_SLUG = os.getenv('BITBUCKET_REPO_SLUG')
 BITBUCKET_COMMIT = os.getenv('BITBUCKET_COMMIT')
 BITBUCKET_PIPELINE_UUID = os.getenv('BITBUCKET_PIPELINE_UUID')
 BITBUCKET_STEP_UUID = os.getenv('BITBUCKET_STEP_UUID')
-PROXIES = {"http": 'http://localhost:29418'}
+PROXIES = {"http": 'http://host.docker.internal:29418'}
 
 def create_report(title, details, report_type, report_id, reporter, result, data):
     url=f"http://api.bitbucket.org/2.0/repositories/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/commit/{BITBUCKET_COMMIT}/reports/{reporter}-{report_id}"

--- a/code-insights/code-insights.py
+++ b/code-insights/code-insights.py
@@ -1,0 +1,92 @@
+import os
+import argparse
+import requests
+import uuid
+
+BITBUCKET_WORKSPACE = os.getenv('BITBUCKET_WORKSPACE')
+BITBUCKET_REPO_SLUG = os.getenv('BITBUCKET_REPO_SLUG')
+BITBUCKET_COMMIT = os.getenv('BITBUCKET_COMMIT')
+BITBUCKET_PIPELINE_UUID = os.getenv('BITBUCKET_PIPELINE_UUID')
+BITBUCKET_STEP_UUID = os.getenv('BITBUCKET_STEP_UUID')
+PROXIES = {"http": 'http://localhost:29418'}
+
+def create_report(title, details, report_type, report_id, reporter, result, data):
+    url=f"http://api.bitbucket.org/2.0/repositories/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/commit/{BITBUCKET_COMMIT}/reports/{reporter}-{report_id}"
+    body = { 
+            "title": details,
+            "details": title,
+            "report_type": report_type,
+            "reporter": reporter,
+            "link": f"https://bitbucket.org/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/addon/pipelines/home#!/results/{BITBUCKET_PIPELINE_UUID}/steps/{BITBUCKET_STEP_UUID}",
+            "result": result,
+            "data": data
+            }
+    r = requests.put(url=url, json=body, proxies=PROXIES)
+    if not r.ok:
+        print(f"Failed to create report {title}")
+        print(r.text)
+
+def create_annotation(title, summary, severity, path, line, reporter, report_id, annotation_type, annotation_id):
+    url=f"http://api.bitbucket.org/2.0/repositories/{BITBUCKET_WORKSPACE}/{BITBUCKET_REPO_SLUG}/commit/{BITBUCKET_COMMIT}/reports/{reporter}-{report_id}/annotations/{reporter}-{annotation_id}"
+    body = { 
+            "title": title,
+            "annotation_type": annotation_type,
+            "summary": summary,
+            "severity": severity,
+            "path": path,
+            "line": line
+            }
+    r = requests.put(url=url, json=body, proxies=PROXIES)
+    if not r.ok:
+        print(f"Failed to create annotation {title}")
+        print(r.text)
+
+def read_results_from_file(file):
+    from junitparser import JUnitXml
+
+    results = []
+    xml = JUnitXml.fromfile(file)
+    if not xml.failures: return []
+    for suite in xml:
+        # handle suites
+        if suite.failures == 0: continue
+        for case in suite:
+            results.append(case.result)
+
+    return results
+
+def build_report_data(result):
+    report_data = [
+            {
+                "title": 'Failures',
+                "type": 'NUMBER',
+                "value": len(result)
+                }
+            ]
+
+    return report_data
+
+parser = argparse.ArgumentParser(description='Interface with the Bitbucket Code Insights API')
+subparsers = parser.add_subparsers(dest="cmd")
+create_parser = subparsers.add_parser('create-report')
+
+create_parser.add_argument('title', type=str)
+create_parser.add_argument('details', type=str)
+create_parser.add_argument('report_type', type=str)
+create_parser.add_argument('reporter', type=str)
+create_parser.add_argument('file', type=str)
+
+args = parser.parse_args()
+
+
+if args.cmd == 'create-report':
+    print(f"Creating Report")
+    results = read_results_from_file(args.file)
+    
+    create_report(args.title,
+            args.details,
+            args.report_type,
+            str(uuid.uuid4()),
+            args.reporter,
+            "FAILED" if len(results) else "PASSED",
+            build_report_data(results))

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -30,4 +30,5 @@ upload_report() {
 validate
 run_owasp_checks
 upload_report
+# Return the exit code from run_owasp_checks
 exit $EXIT_CODE

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -24,7 +24,7 @@ run_owasp_checks() {
 }
 
 upload_report() {
-     python3 /usr/bin/code-insights/code-insights.py junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml $OLDPWD/$SCAN_PATH
+     python3 /usr/bin/code-insights/code-insights.py junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" ${OUTPUT_PATH}dependency-check-junit.xml $SCAN_PATH
 }
 
 validate

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -24,7 +24,7 @@ run_owasp_checks() {
 }
 
 upload_report() {
-     cd /usr/bin/code-insights && pipenv run code-insights junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml $OLDPWD/$SCAN_PATH
+     python3 /usr/bin/code-insights/code-insights.py junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml $OLDPWD/$SCAN_PATH
 }
 
 validate

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -24,7 +24,7 @@ run_owasp_checks() {
 }
 
 upload_report() {
-     cd /usr/bin/code-insights && pipenv run code-insights create-report "Dependency Scan" "OWASP Depenency scan results" "OWASP" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml
+     cd /usr/bin/code-insights && pipenv run code-insights create-report "Dependency Scan" "OWASP Depenency scan results" "SECURITY" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml
 }
 
 validate

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -24,7 +24,7 @@ run_owasp_checks() {
 }
 
 upload_report() {
-     cd /usr/bin/code-insights && pipenv run code-insights create-report "Dependency Scan" "OWASP Depenency scan results" "OWASP" "owasp-dependency-check-pipe" /build/${OUTPUT_PATH}dependency-check-junit.xml
+     cd /usr/bin/code-insights && pipenv run code-insights create-report "Dependency Scan" "OWASP Depenency scan results" "OWASP" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml
 }
 
 validate

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -24,7 +24,7 @@ run_owasp_checks() {
 }
 
 upload_report() {
-     python3 /usr/bin/code-insights/code-insights.py junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" ${OUTPUT_PATH}dependency-check-junit.xml $SCAN_PATH
+     python3 /usr/bin/code-insights/code-insights.py junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} for known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" ${OUTPUT_PATH}dependency-check-junit.xml $SCAN_PATH
 }
 
 validate

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -12,13 +12,22 @@ validate() {
 run_owasp_checks() {
      OWASP_PATH="/usr/share/dependency-check/bin/dependency-check.sh"
 
+     # Capture the exist code from run_owasp_checks.
+     # Even if this fails we still want to generate the report.
+
      if [[ -z "${SUPPRESSION_FILE_PATH}" ]]; then
-          ${OWASP_PATH} --format JUNIT --format HTML --project ${BITBUCKET_REPO_FULL_NAME} --enableExperimental --out ${OUTPUT_PATH} -s ${SCAN_PATH} --junitFailOnCVSS ${CVSS_FAIL_LEVEL} --failOnCVSS ${CVSS_FAIL_LEVEL}
+          ${OWASP_PATH} --format JUNIT --format HTML --project ${BITBUCKET_REPO_FULL_NAME} --enableExperimental --out ${OUTPUT_PATH} -s ${SCAN_PATH} --junitFailOnCVSS ${CVSS_FAIL_LEVEL} --failOnCVSS ${CVSS_FAIL_LEVEL} || EXIT_CODE=$?
      else
-          ${OWASP_PATH} --format JUNIT --format HTML --project ${BITBUCKET_REPO_FULL_NAME} --enableExperimental --out ${OUTPUT_PATH} -s ${SCAN_PATH} --junitFailOnCVSS ${CVSS_FAIL_LEVEL} --failOnCVSS ${CVSS_FAIL_LEVEL} --suppression ${SUPPRESSION_FILE_PATH}
+          ${OWASP_PATH} --format JUNIT --format HTML --project ${BITBUCKET_REPO_FULL_NAME} --enableExperimental --out ${OUTPUT_PATH} -s ${SCAN_PATH} --junitFailOnCVSS ${CVSS_FAIL_LEVEL} --failOnCVSS ${CVSS_FAIL_LEVEL} --suppression ${SUPPRESSION_FILE_PATH} || EXIT_CODE=$?
      fi
+
+}
+
+upload_report() {
+     cd /usr/bin/code-insights && pipenv run code-insights create-report "Dependency Scan" "OWASP Depenency scan results" "OWASP" "owasp-dependency-check-pipe" /build/${OUTPUT_PATH}dependency-check-junit.xml
 }
 
 validate
 run_owasp_checks
-
+upload_report
+exit $EXIT_CODE

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -24,7 +24,7 @@ run_owasp_checks() {
 }
 
 upload_report() {
-     cd /usr/bin/code-insights && pipenv run code-insights create-report "Dependency Scan" "OWASP Depenency scan results" "SECURITY" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml
+     cd /usr/bin/code-insights && pipenv run code-insights junit-report "OWASP Dependency Scan" "Results produced when scanning ${SCAN_PATH} known OWASP vulnerabilities." "SECURITY" "owasp-dependency-check-pipe" $OLDPWD/${OUTPUT_PATH}dependency-check-junit.xml $OLDPWD/$SCAN_PATH
 }
 
 validate


### PR DESCRIPTION
This pull request adds support for [Bitbucket Code Insights](https://support.atlassian.com/bitbucket-cloud/docs/code-insights/).

This pipe will now add a report to the pull request with the number of failures and a link to the test results.

It does not yet add the individual errors, these would need to be done as annotations.

The code insights wrapper command lives in `./code-insights` it is a python 3 script.
This should be pulled out of this pipe in the future as it can be reused.
![image](https://user-images.githubusercontent.com/9162298/149453611-610ed8cc-19ce-47b8-beca-c356a7cd9d7e.png)
![image](https://user-images.githubusercontent.com/9162298/149453647-c4a8ff5d-e94f-45c3-933c-40b32fd9af5a.png)


`DO-1054`