### PR TITLE
Fix call to path exists

### DIFF
--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -43,7 +43,7 @@ class OWASPDependencyCheck(Pipe):
                 '-s', self.scan_path,
                 '--junitFailOnCVSS', self.cvss_fail_level,
                 '--failOnCVSS', self.cvss_fail_level]
-        if self.suppression_path and os.exists(self.suppression_path):
+        if self.suppression_path and os.path.exists(self.suppression_path):
             owasp_command.append('--suppression')
             owasp_command.append(self.suppression_path)
 


### PR DESCRIPTION
Pipe is currently failing with:
```
Traceback (most recent call last):
  File "/pipe.py", line 122, in <module>
    pipe.run()
  File "/pipe.py", line 112, in run
    self.run_owasp_check()
  File "/pipe.py", line 46, in run_owasp_check
    if self.suppression_path and os.exists(self.suppression_path):
AttributeError: module 'os' has no attribute 'exists'
```

This should fix it up