### PR TITLE
introduce ossIndexUsername and ossIndexPassword flags in response to the rate limiting

### DIFF
--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -23,6 +23,8 @@ class OWASPDependencyCheck(Pipe):
         super().__init__(*args, **kwargs)
         self.scan_path = self.get_variable('SCAN_PATH')
         self.suppression_path = self.get_variable('SUPPRESSION_FILE_PATH') if self.get_variable('SUPPRESSION_FILE_PATH') else './suppression.xml'
+        self.ossindexusername = self.get_variable('OSSINDEXUSERNAME') if self.get_variable('OSSINDEXUSERNAME')
+        self.ossindexpassword = self.get_variable('OSSINDEXPASSWORD') if self.get_variable('OSSINDEXPASSWORD')
         self.cvss_fail_level = self.get_variable('CVSS_FAIL_LEVEL') if self.get_variable('CVSS_FAIL_LEVEL') else '1'
         self.out_path = self.get_variable('OUTPUT_PATH') if self.get_variable('OUTPUT_PATH') else './test-results/'
         self.bitbucket_repo = os.getenv('BITBUCKET_REPO_FULL_NAME') if os.getenv('BITBUCKET_REPO_FULL_NAME') else 'Unknown Project'
@@ -46,6 +48,12 @@ class OWASPDependencyCheck(Pipe):
         if self.suppression_path and os.path.exists(self.suppression_path):
             owasp_command.append('--suppression')
             owasp_command.append(self.suppression_path)
+
+        if self.self.ossindexusername and self.self.ossindexpassword:
+            owasp_command.append('--ossIndexUsername')
+            owasp_command.append(self.ossindexusername)
+            owasp_command.append('--ossIndexPassword')
+            owasp_command.append(self.ossindexpassword)
 
         owasp = subprocess.run(owasp_command,
                 universal_newlines=True)


### PR DESCRIPTION
**Issue**
Recent OWASP pipeline failures with `[WARN] An error occurred while analyzing '/opt/atlassian/pipelines/agent/build/composer.lock' (Sonatype OSS Index Analyzer).` error, e.g.
![image](https://github.com/aligent/owasp-dependency-check-pipe/assets/55869976/5144fb4d-caa3-499a-a369-63ebaccc7710)

**Cause**
Sonatype OSS Index has tightened their rate limit further. From their [homepage](https://ossindex.sonatype.org/):
```
Starting April 24, 2023, unregistered users will be limited to 40 requests per month on OSS Index. 
We encourage you to create an account and authenticate with OSS Index to increase your usage limits. 
Authenticated users may have access to additional features and higher usage limits.
```

**Solution**
- Add OSS username and password flags and provides them as env vars
- This, however, may not start working immediately due to another issue on Sonatype OSS Index - https://github.com/jeremylong/DependencyCheck/issues/5752
