### PR TITLE
Fix/backport bitbucket upstream

### DIFF
--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -101,7 +101,10 @@ class OWASPDependencyCheck(Pipe):
         report_id = str(uuid.uuid4())
 
         if self.bitbucket_repo != 'Unknown Project':
-            bitbucket_api = Bitbucket(proxies={"http": 'http://host.docker.internal:29418'})
+            bitbucket_api = Bitbucket(
+                proxies={"http": 'http://host.docker.internal:29418'},
+                protocol="http"
+            )
 
 
             failures = read_failures_from_file(

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -35,8 +35,8 @@ class OWASPDependencyCheck(Pipe):
         self.bitbucket_repo = os.getenv('BITBUCKET_REPO_FULL_NAME') if os.getenv('BITBUCKET_REPO_FULL_NAME') else 'Unknown Project'
         self.bitbucket_workspace  = os.getenv('BITBUCKET_WORKSPACE')
         self.bitbucket_repo_slug = os.getenv('BITBUCKET_REPO_SLUG')
-        self.bitbucket_pipeline_uuid = os.getenv('BITBUCKET_PIPELINE_UUID')
-        self.bitbucket_step_uuid = os.getenv('BITBUCKET_STEP_UUID')
+        self.bitbucket_pipeline_uuid = os.getenv('BITBUCKET_PIPELINE_UUID').strip("{}")
+        self.bitbucket_step_uuid = os.getenv('BITBUCKET_STEP_UUID').strip("{}")
         self.bitbucket_commit = os.getenv('BITBUCKET_COMMIT')
 
     def run_owasp_check(self):


### PR DESCRIPTION
Issue: Pipeline reporting `{"type": "error", "error": {"message": "Resource not found"}}` error on uploading the report.

- strip curly brackets added to UUIDs
- specify http protocol for API endpoints not supporting https


Similar change: https://github.com/aligent/phpstan-pipe/pull/10