### PR TITLE
Remove OSS Index and NVD Api credential build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM owasp/dependency-check
 
-ARG NVD_API_KEY
-ARG OSSINDEX_USERNAME
-ARG OSSINDEX_PASSWORD
 ARG UPDATE_DB
-ARG NVD_API_DELAY
+ARG NVD_API_FEED
 
 USER root
 RUN apk add wget bash
@@ -23,7 +20,7 @@ RUN python3 -m pip install --no-cache-dir -r /requirements.txt
 
 # Initialise OWASP DB if UPDATE_DB = true
 # https://github.com/jeremylong/DependencyCheck/blob/2d5fbd9719ddd55a59aea8c234c11e43eaafe26d/Dockerfile#L50
-RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly --nvdApiKey ${NVD_API_KEY} --ossIndexUsername ${OSSINDEX_USERNAME} --ossIndexPassword ${OSSINDEX_PASSWORD} --nvdMaxRetryCount 20 --nvdApiDelay ${NVD_API_DELAY}
+RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly ${NVD_API_FEED:+--nvdDataFeed ${NVD_API_FEED}}
 
 COPY pipe /
 USER root

--- a/hooks/build
+++ b/hooks/build
@@ -2,9 +2,6 @@
 
 docker build \
     --build-arg UPDATE_DB=$UPDATE_DB \
-    --build-arg NVD_API_KEY=$NVD_API_KEY \
-    --build-arg OSSINDEX_PASSWORD=$OSSINDEX_PASSWORD \
-    --build-arg OSSINDEX_USERNAME=$OSSINDEX_USERNAME \
-    --build-arg NVD_API_DELAY=$NVD_API_DELAY \
+    --build-arg NVD_API_FEED=$NVD_API_FEED \ 
     -f $DOCKERFILE_PATH \
     -t $IMAGE_NAME .


### PR DESCRIPTION
Remove the credential build args and add an optional `NVD_API_FEED` arg which will be used in the new codebuild pipeline to use our private mirror. 