### PR TITLE
Lock upstream image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/dependency-check
+FROM owasp/dependency-check:11.1.1
 
 ARG UPDATE_DB
 ARG NVD_API_FEED


### PR DESCRIPTION
Lock the upstream image tag to version 11 as there seems to be an issue with version 12 misidentifying composer packages. 