### PR TITLE
ADK-336: Use latest to address vulnerable packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*@krishanthisera @aligent/aligent-devops
+* @aligent/devops

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/dependency-check:12.1.5
+FROM owasp/dependency-check:12.2.1
 
 ARG UPDATE_DB
 ARG NVD_API_FEED


### PR DESCRIPTION
**Description of the proposed changes**

- stdlib: go1.25.1 --> go1.26.2
- openssl: 3.5.2-r0 --> 3.5.6-r0
- nodejs: 22.16.0-r2 --> 24.14.1-r0
- pcre: 10.43-r1 --> 10.47-r0

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

