### PR TITLE
AKD-336: move from data feed to api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM owasp/dependency-check:12.2.1
 
 ARG UPDATE_DB
-ARG NVD_API_FEED
+ARG NVD_API_KEY
 
 USER root
 RUN apk add wget bash
@@ -18,8 +18,7 @@ COPY requirements.txt /
 RUN python3 -m pip install --no-cache-dir --break-system-packages -r /requirements.txt
 
 # Initialise OWASP DB if UPDATE_DB = true
-# https://github.com/jeremylong/DependencyCheck/blob/2d5fbd9719ddd55a59aea8c234c11e43eaafe26d/Dockerfile#L50
-RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly ${NVD_API_FEED:+--nvdDatafeed=${NVD_API_FEED}}
+RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly ${NVD_API_KEY:+--nvdApiKey=${NVD_API_KEY}}
 
 COPY pipe /
 USER root


### PR DESCRIPTION
**Description of the proposed changes**

NVD has deprecated Data-feed in favour of API key. 
https://github.com/dependency-check/DependencyCheck#nvd-api-key-highly-recommended

The lack of key has been causing 429 errors upon update:
```
2026-04-27T04:31:14Z #12 216.2 Caused by: io.github.jeremylong.openvulnerability.client.nvd.NvdApiException: NVD Returned Status Code: 429
```

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

