### PR TITLE
AKD-336: add delay to accommodate Rate Limit of NVD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY requirements.txt /
 RUN python3 -m pip install --no-cache-dir --break-system-packages -r /requirements.txt
 
 # Initialise OWASP DB if UPDATE_DB = true
-RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly ${NVD_API_KEY:+--nvdApiKey=${NVD_API_KEY}}
+# nvdApiDelay of 700ms prevents 429 rate limit errors from NVD API, where "50 requests in a rolling 30 second window" rule is applied.
+RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly ${NVD_API_KEY:+--nvdApiKey=${NVD_API_KEY} --nvdApiDelay=700}
 
 COPY pipe /
 USER root


### PR DESCRIPTION
**Description of the proposed changes**
- https://nvd.nist.gov/developers/start-here
```
the rate limit with an API key is 50 requests in a rolling 30 second window
```
30 sec / 50 req = 600ms < 700ms (with a bit of leeway)

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/.github/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

