### PR TITLE
Feature/do 2030 image build migration

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,36 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - feature/DO-2030_image_build_migration
+  schedule:
+    # Weekly rebuild to update NVD database (Sundays at 2am UTC)
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+    inputs:
+      force_db_update:
+        description: 'Force NVD database update (ignore cache)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    uses: aligent/workflows/.github/workflows/docker-build.yml@feature/DO-2030_docker_image_build
+    with:
+      image-name: aligent/owasp-dependency-check
+      dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+      timeout-minutes: 360
+      build-args: |
+        UPDATE_DB=true
+      no-cache: ${{ github.event_name == 'schedule' || inputs.force_db_update == true }}
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+      build-secrets: |
+        NVD_API_KEY=${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
       timeout-minutes: 360
       build-args: |
         UPDATE_DB=true
-      no-cache: ${{ github.event_name == 'schedule' || inputs.force_db_update == true }}
+      no-cache: ${{ inputs.force_db_update == true }}
     secrets:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       build-secrets: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: aligent/workflows/.github/workflows/docker-build.yml@feature/DO-2030_docker_image_build
+    uses: aligent/workflows/.github/workflows/docker-build.yml@main
     with:
       image-name: aligent/owasp-dependency-check-pipe
       dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,8 +6,8 @@ on:
       - main
       - feature/DO-2030_image_build_migration
   schedule:
-    # Weekly rebuild to update NVD database (Sundays at 2am UTC)
-    - cron: '0 2 * * 0'
+    # Daily rebuild to keep NVD database fresh (delta updates)
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       force_db_update:
@@ -24,7 +24,7 @@ jobs:
   build-and-push:
     uses: aligent/workflows/.github/workflows/docker-build.yml@feature/DO-2030_docker_image_build
     with:
-      image-name: aligent/owasp-dependency-check
+      image-name: aligent/owasp-dependency-check-pipe
       dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
       timeout-minutes: 360
       build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM owasp/dependency-check:12.2.1
 
 ARG UPDATE_DB
-ARG NVD_API_KEY
 
 USER root
 RUN apk add wget bash
@@ -18,8 +17,13 @@ COPY requirements.txt /
 RUN python3 -m pip install --no-cache-dir --break-system-packages -r /requirements.txt
 
 # Initialise OWASP DB if UPDATE_DB = true
-# nvdApiDelay of 600ms prevents 429 rate limit errors from NVD API, where "50 requests in a rolling 30 second window" rule is applied.
-RUN ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly ${NVD_API_KEY:+--nvdApiKey=${NVD_API_KEY} --nvdApiDelay=600}
+# nvdApiDelay of 1000ms and nvdApiResultsPerPage of 1000 prevent 429 rate limit errors from NVD API.
+# NVD_API_KEY is passed as a BuildKit secret to avoid exposing it in build logs.
+# mode=0444 is required because BuildKit secrets default to root-only (0400), but this runs as USER 1000.
+RUN --mount=type=secret,id=NVD_API_KEY,mode=0444 \
+    NVD_KEY=$(cat /run/secrets/NVD_API_KEY 2>/dev/null || echo "") && \
+    ! ${UPDATE_DB} || /usr/share/dependency-check/bin/dependency-check.sh --updateonly \
+    ${NVD_KEY:+--nvdApiKey=${NVD_KEY}} --nvdApiDelay=1000 --nvdApiResultsPerPage=1000
 
 COPY pipe /
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM owasp/dependency-check:12.2.1
+# Self-referential: pulls previous build which contains recent NVD database.
+# Delta updates are fast (<7 days). Schedule builds every few days to stay fresh.
+# Bootstrap: first build requires full DB download (~4-10 hours).
+FROM aligent/owasp-dependency-check-pipe:latest
 
 ARG UPDATE_DB
 
@@ -16,7 +19,7 @@ USER 1000
 COPY requirements.txt /
 RUN python3 -m pip install --no-cache-dir --break-system-packages -r /requirements.txt
 
-# Initialise OWASP DB if UPDATE_DB = true
+# Run delta update if UPDATE_DB = true (fetches only new CVEs since base image was built).
 # nvdApiDelay of 1000ms and nvdApiResultsPerPage of 1000 prevent 429 rate limit errors from NVD API.
 # NVD_API_KEY is passed as a BuildKit secret to avoid exposing it in build logs.
 # mode=0444 is required because BuildKit secrets default to root-only (0400), but this runs as USER 1000.

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,26 @@
+# Bootstrap Dockerfile for initial NVD database seed image.
+#
+# Use this to create the first seed image with a full NVD database download.
+# Once pushed, the main Dockerfile uses self-referential builds for fast delta updates.
+#
+# This build takes 4-10 hours depending on NVD API load.
+#
+# Build (on local machine - no GitHub Actions time limit):
+#   docker build -f Dockerfile.db \
+#     --platform linux/amd64 \
+#     --build-arg NVD_API_KEY=$NVD_API_KEY \
+#     -t aligent/owasp-dependency-check-pipe:latest .
+#
+# Push:
+#   docker push aligent/owasp-dependency-check-pipe:latest
+#
+# After the seed is pushed, daily GitHub Actions builds will do fast delta updates.
+
+FROM owasp/dependency-check:12.2.1
+
+ARG NVD_API_KEY
+
+# Download full NVD database.
+# nvdApiDelay of 1000ms and nvdApiResultsPerPage of 1000 prevent 429 rate limit errors from NVD API.
+RUN /usr/share/dependency-check/bin/dependency-check.sh --updateonly \
+    ${NVD_API_KEY:+--nvdApiKey=${NVD_API_KEY}} --nvdApiDelay=1000 --nvdApiResultsPerPage=1000

--- a/README.md
+++ b/README.md
@@ -41,4 +41,27 @@ The following command with world-writable `test-results` directory under project
 docker run --rm -e OUTPUT_PATH="/tmp/test-results/" -e CVSS_FAIL_LEVEL=1 -e SCAN_PATH=./composer.lock -v $PWD:/build --workdir=/build aligent/owasp-dependency-check-pipe
 ```
 
-Commits published to the `main` branch  will trigger an automated build.
+## CI/CD
+
+Docker images are built and pushed to Docker Hub via GitHub Actions. The workflow:
+
+- Triggers on pushes to `main` branch
+- Runs weekly (Sundays at 2am UTC) to update the NVD database
+- Can be manually triggered with optional cache bypass
+
+### Required Secrets
+
+Configure the following secrets in your GitHub repository:
+
+| Secret | Description |
+|--------|-------------|
+| `DOCKERHUB_USERNAME` | Docker Hub username |
+| `DOCKERHUB_TOKEN` | Docker Hub access token |
+| `NVD_API_KEY` | NVD API key for faster database updates |
+
+### Caching
+
+The workflow uses GitHub Actions cache to store Docker build layers, significantly reducing build times for subsequent builds. The NVD database layer is cached and reused unless:
+
+- The scheduled weekly rebuild runs (forces fresh database download)
+- Manual trigger with "Force NVD database update" option enabled

--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-docker build \
-    --build-arg UPDATE_DB=$UPDATE_DB \
-    --build-arg NVD_API_KEY=$NVD_API_KEY \
-    -f $DOCKERFILE_PATH \
-    -t $IMAGE_NAME .


### PR DESCRIPTION
**Description of the proposed changes**

- Use Github Actions for docker image build
- Self-update the image `aligent/owasp-dependency-check-pipe` instead of using the upstream `owasp/owasp-dependency-check-pipe`
  - this keeps the build time as short as a few minutes, downloading deltas only
  - the update/build/push runs every day to avoid the upstream from being outdated; it would require a full update if it's more than a week behind
  - downloading updates onto the upstream takes around 6-9 hours even with the API key, easily exceeding Github's build time limit of 6 hours
  - instead, a Docker file `Dockerfile.db` has been added for the local build of `aligent/owasp-dependency-check-pipe` using the upstream, with detailed comment in it

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/.github/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

Yeah.. now I'm leaning into stopping maintaining this pipe, due to the Magento-related false-positives. Until then, however, we may as well keep this up-to-date.

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

**Time Tracking**

ABC-xxx: code review, select project XXXX