### PR TITLE
Flatten image into single layer to reset FROM-chain depth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
+# ---- Stage 1: delta-update the NVD database on top of the previous build ----
 # Self-referential: pulls previous build which contains recent NVD database.
 # Delta updates are fast (<7 days). Schedule builds every few days to stay fresh.
 # Bootstrap: first build requires full DB download (~4-10 hours).
-FROM aligent/owasp-dependency-check-pipe:latest
+FROM aligent/owasp-dependency-check-pipe:latest AS previous
 
 ARG UPDATE_DB
 
@@ -32,6 +33,29 @@ COPY pipe /
 USER root
 RUN chmod a+x /*.py
 
+# ---- Stage 2: flatten into a single layer to reset the FROM-chain depth ----
+# The self-referential FROM above grows the overlay layer chain on every build.
+# Without this, the chain eventually exceeds Docker's 128-layer limit and the
+# export/import step fails with "max depth exceeded". Copying the whole rootfs
+# from the previous stage into a scratch base collapses it back to one layer.
+# COPY does not carry image metadata, so the config below is restated verbatim
+# from the base image (verified against `docker inspect`); the inherited dotnet
+# runtime vars are kept because the .NET assembly analyzer relies on them.
+FROM scratch
+COPY --from=previous / /
+
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    JAVA_HOME="/opt/jdk" \
+    JAVA_OPTS="-Danalyzer.assembly.dotnet.path=/usr/bin/dotnet -Danalyzer.bundle.audit.path=/usr/bin/bundle-audit -Danalyzer.golang.path=/usr/local/go/bin/go" \
+    ODC_NAME="dependency-check-docker" \
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true \
+    DOTNET_VERSION=8.0.25 \
+    PYTHONUNBUFFERED=1 \
+    user="dependencycheck"
+
+VOLUME ["/report", "/src"]
+WORKDIR /src
 USER 1000
 
 ENTRYPOINT ["/pipe.py"]


### PR DESCRIPTION
**Description of the proposed changes**

The self-referential FROM grows the overlay layer chain on every build. After enough daily builds it exceeded Docker's 128-layer limit, failing the export/import step with "max depth exceeded".

Add a second stage that copies the rootfs from the delta-update stage into a scratch base, collapsing the chain back to a single layer. Image config (ENV/VOLUME/WORKDIR/USER/ENTRYPOINT) is restated verbatim since COPY does not carry metadata; verified against docker inspect.


**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/.github/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

**Time Tracking**

ABC-xxx: code review, select project XXXX